### PR TITLE
ci: install requirements to validate imports

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install deps
+        run: pip install -r requirements.txt
+
       - name: Check Python syntax
         run: python -m py_compile $(git ls-files '*.py')
 
@@ -32,6 +35,8 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install deps
+        run: pip install -r requirements.txt
       - name: Test daemon import
         env:
           PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
Install project dependencies in CI before running smoke tests.

This adds a step to both the  and  jobs to run Requirement already satisfied: numpy in /home/codespace/.local/lib/python3.12/site-packages (from -r requirements.txt (line 1)) (2.3.5)
Requirement already satisfied: pandas in /home/codespace/.local/lib/python3.12/site-packages (from -r requirements.txt (line 2)) (2.3.3)
Requirement already satisfied: matplotlib in /home/codespace/.local/lib/python3.12/site-packages (from -r requirements.txt (line 3)) (3.10.7)
Requirement already satisfied: lifelines in /usr/local/python/3.12.1/lib/python3.12/site-packages (from -r requirements.txt (line 4)) (0.30.0)
Requirement already satisfied: python-dateutil>=2.8.2 in /home/codespace/.local/lib/python3.12/site-packages (from pandas->-r requirements.txt (line 2)) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in /home/codespace/.local/lib/python3.12/site-packages (from pandas->-r requirements.txt (line 2)) (2025.2)
Requirement already satisfied: tzdata>=2022.7 in /home/codespace/.local/lib/python3.12/site-packages (from pandas->-r requirements.txt (line 2)) (2025.2)
Requirement already satisfied: contourpy>=1.0.1 in /home/codespace/.local/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 3)) (1.3.3)
Requirement already satisfied: cycler>=0.10 in /home/codespace/.local/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 3)) (0.12.1)
Requirement already satisfied: fonttools>=4.22.0 in /home/codespace/.local/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 3)) (4.61.0)
Requirement already satisfied: kiwisolver>=1.3.1 in /home/codespace/.local/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 3)) (1.4.9)
Requirement already satisfied: packaging>=20.0 in /home/codespace/.local/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 3)) (25.0)
Requirement already satisfied: pillow>=8 in /home/codespace/.local/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 3)) (12.0.0)
Requirement already satisfied: pyparsing>=3 in /home/codespace/.local/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 3)) (3.2.5)
Requirement already satisfied: scipy>=1.7.0 in /home/codespace/.local/lib/python3.12/site-packages (from lifelines->-r requirements.txt (line 4)) (1.16.3)
Requirement already satisfied: autograd>=1.5 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from lifelines->-r requirements.txt (line 4)) (1.8.0)
Requirement already satisfied: autograd-gamma>=0.3 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from lifelines->-r requirements.txt (line 4)) (0.5.0)
Requirement already satisfied: formulaic>=0.2.2 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from lifelines->-r requirements.txt (line 4)) (1.2.1)
Requirement already satisfied: interface-meta>=1.2.0 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from formulaic>=0.2.2->lifelines->-r requirements.txt (line 4)) (1.3.0)
Requirement already satisfied: narwhals>=1.17 in /home/codespace/.local/lib/python3.12/site-packages (from formulaic>=0.2.2->lifelines->-r requirements.txt (line 4)) (2.10.2)
Requirement already satisfied: typing-extensions>=4.2.0 in /home/codespace/.local/lib/python3.12/site-packages (from formulaic>=0.2.2->lifelines->-r requirements.txt (line 4)) (4.15.0)
Requirement already satisfied: wrapt>=1.0 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from formulaic>=0.2.2->lifelines->-r requirements.txt (line 4)) (2.0.1)
Requirement already satisfied: six>=1.5 in /home/codespace/.local/lib/python3.12/site-packages (from python-dateutil>=2.8.2->pandas->-r requirements.txt (line 2)) (1.17.0) so that import-time checks validate real package availability (e.g. ).

No changes to tests themselves; only installs deps prior to running the existing smoke tests.,